### PR TITLE
Add compatibility with Statamic v4+

### DIFF
--- a/src/Fieldtypes/SecretField.php
+++ b/src/Fieldtypes/SecretField.php
@@ -26,7 +26,7 @@ class SecretField extends Fieldtype
         }
 
         try {
-            return StatamicSecretFacade::decryptString($value);
+            return StatamicSecretFacade::decryptString(base64_decode($value));
         } catch (\ErrorException $e) {
             // Oh no! We couldn't decrypt the value.
             return '<!-- Decryption error. Has the keys been overwritten? -->';
@@ -46,7 +46,7 @@ class SecretField extends Fieldtype
         }
 
         try {
-            return StatamicSecretFacade::decryptString($data);
+            return StatamicSecretFacade::decryptString(base64_decode($data));
         } catch (\ErrorException $e) {
             // Oh no! We couldn't decrypt the value.
             return '(decryption failed)';
@@ -65,7 +65,7 @@ class SecretField extends Fieldtype
             return '';
         }
 
-        return StatamicSecretFacade::encryptString(trim($data));
+        return base64_encode(StatamicSecretFacade::encryptString(trim($data)));
     }
 
     public function preProcessIndex($value)

--- a/src/StatamicSecret.php
+++ b/src/StatamicSecret.php
@@ -138,4 +138,19 @@ class StatamicSecret implements Encrypter
             return $this->handler->{$name}($arguments);
         }
     }
+
+    public function getKey()
+    {
+        // required by the contract
+    }
+
+    public function getAllKeys()
+    {
+        // required by the contract
+    }
+
+    public function getPreviousKeys()
+    {
+        // required by the contract
+    }
 }


### PR DESCRIPTION
> [!CAUTION]
> Already encrypted data in files has to be migrated by re-saving it with base64 encoding

- Implements missing methods of the `Illuminate\Contracts\Encryption\Encrypter` interface
- Encodes / decodes values with base64 to prevent exceptions being thrown by the queue while saving

Fixes: #2 